### PR TITLE
add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @reaktivstudios/admins @reaktivstudios/reviewers 


### PR DESCRIPTION
# Description

Adds Reaktiv Admins and Reaktiv Reviewers as code owners for the entire repo.

Fixes #21 
Fixes #22 
