### PR TITLE
add pr-labeler and relase-drafter actions

### DIFF
--- a/.github/action_templates/pr-labeler.yml
+++ b/.github/action_templates/pr-labeler.yml
@@ -1,0 +1,6 @@
+feature: ['feature/*', 'feat/*', 'feature-*']
+minor: ['feature/*', 'feat/*', 'feature-*']
+fix: ['fix/*', 'hotfix/*', 'fix-*', 'hotfix-*']
+patch: ['fix/*', 'hotfix/*', 'fix-*', 'hotfix-*']
+chore: ['chore/*', 'maintenance/*', 'chore-*', 'maintentance-*']
+skip-changelog: ['skip/*', 'exclude/*', 'skip-*', 'exclude-*']

--- a/.github/action_templates/release-drafter.yml
+++ b/.github/action_templates/release-drafter.yml
@@ -1,0 +1,38 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+exclude-labels:
+  - 'skip-changelog'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS
+  

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-labeler:
+    permissions:
+      contents: read # for TimonVS/pr-labeler-action to read config file
+      pull-requests: write # for TimonVS/pr-labeler-action to add labels in PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/action_templates/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,17 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v6
+        config-name: action_templates/release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Adds the PR Labeler and Release Drafter git hub actions.

PR Labeler adds labels to PRs based on the branch name.

Release drafter builds a release based on merged PRs. It uses labels to decide the semver and add release notes.

Fixes #28 
