### PR TITLE
add maintenance and depencencies labels for the maintenance category

### DIFF
--- a/.github/action_templates/release-drafter.yml
+++ b/.github/action_templates/release-drafter.yml
@@ -11,7 +11,10 @@ categories:
       - 'bugfix'
       - 'bug'
   - title: '🧰 Maintenance'
-    label: 'chore'
+    labels:
+      - 'chore'
+      - 'maintenance'
+      - 'dependencies'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
 exclude-labels:


### PR DESCRIPTION
# Description

Dependabot adds the "dependencies" label and instead of having to add the "chore" label, this will include that label for the Maintenance category in Release Drafter.
