### PR TITLE
prep for release 2.0

### DIFF
--- a/rkv-site-guide.php
+++ b/rkv-site-guide.php
@@ -7,7 +7,7 @@
  * Description: Adds the site guide to the site.
  * Author: Reaktiv Studios
  * Author URI: https://reaktivstudios.com
- * Version: 1.1.1
+ * Version: 2.0.0
  * License: GPL2+
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  *


### PR DESCRIPTION
# Description

This just version bumps for release 2.0. 

These are breaking changes that were published as release 1.1.1 previously but really need to be a major version since it removes the internal notion sync in favor of a plugin.
