### PR TITLE
add compatibility with wp101

### DIFF
--- a/inc/classes/Core.php
+++ b/inc/classes/Core.php
@@ -39,6 +39,9 @@ class Core {
 		// Templates.
 		'\RKV\Guide\Template\Enqueue',
 		'\RKV\Guide\Template\Title',
+
+		// WP 101.
+		'\RKV\Guide\WP_101\Compat',
 	];
 
 	/**

--- a/inc/classes/WP_101/Compat.php
+++ b/inc/classes/WP_101/Compat.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Adds compatibility for WP101 plugin.
+ * 
+ * @package rkv-guide
+ */
+
+namespace RKV\Guide\WP_101;
+
+/**
+ * WP 101 Compat class.
+ */
+class Compat {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		if ( did_action( 'init' ) || doing_action( 'init' ) ) {
+			$this->init();
+		}
+
+		add_action( 'init', [ $this, 'init' ] );
+	}
+
+	/**
+	 * Initialize compatibility features.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		if ( ! defined( 'WP101_INC' ) ) {
+			return;
+		}
+
+		// Remove WP101's admin menu.
+		remove_action( 'admin_menu', 'WP101\Admin\register_menu_pages' );
+		add_action( 'admin_menu', [ $this, 'register_menu_pages' ] );
+
+		// Enqueue WP101 scripts and styles.
+		remove_action( 'admin_enqueue_scripts', 'WP101\Admin\enqueue_scripts' );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+	}
+
+	/**
+	 * Register the WP101 settings page.
+	 *
+	 * @return void
+	 */
+	public function register_menu_pages() {
+		add_submenu_page(
+			'site-guide',
+			_x( 'WP101', 'page title', 'rkv-guide' ),
+			_x( 'Video Tutorials', 'menu title', 'rkv-guide' ),
+			'read',
+			'wp101',
+			'WP101\Admin\render_listings_page',
+			'dashicons-video-alt3'
+		);
+
+		add_submenu_page(
+			'site-guide',
+			_x( 'WP101 Settings', 'page title', 'rkv-guide' ),
+			_x( 'WP101 Settings', 'menu title', 'rkv-guide' ),
+			'manage_options',
+			'wp101-settings',
+			'WP101\Admin\render_settings_page'
+		);
+	}
+
+	/**
+	 * Register scripts and styles to be used in WP admin.
+	 *
+	 * @param string $hook The page being loaded.
+	 */
+	public function enqueue_scripts( $hook ) {
+		// Only enqueue on WP101 pages.
+		if ( false !== strpos( $hook, 'guide_page_wp101' ) ) {
+			wp_register_style(
+				'wp101-admin',
+				WP101_URL . '/assets/css/wp101-admin.css',
+				null,
+				WP101_VERSION,
+				'all'
+			);
+
+			wp_register_script(
+				'wp101-admin',
+				WP101_URL . '/assets/js/wp101-admin.min.js',
+				array( 'jquery-ui-accordion' ),
+				WP101_VERSION,
+				true
+			);
+
+			wp_enqueue_style( 'wp101-admin' );
+			wp_enqueue_script( 'wp101-admin' );
+
+			add_action( 'admin_notices', 'WP101\Admin\display_api_errors' );
+		}
+	}
+}


### PR DESCRIPTION
# Description

Adds a compat class for wp101 that moves the wp101 menu items under the guide menu and ensures the scripts load in the correct submenu page.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I added this in a site with wp101 to verify the menu items show under the guide menu.

- [ ] The wp101 menu items show under the guide admin menu

**Test Configuration**:
* WordPress version: 6.8.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
