### PR TITLE
Remove has_cap filter

### DIFF
--- a/inc/classes/Post_Type/Guide.php
+++ b/inc/classes/Post_Type/Guide.php
@@ -65,7 +65,6 @@ class Guide extends Base {
 		}
 
 		add_action( 'pre_get_posts', [ $this, 'limit_post_access' ] );
-		add_filter( 'user_has_cap', [ $this, 'user_has_cap' ], 10, 3 );
 		add_filter( 'post_type_link', [ $this, 'post_type_link' ], 10, 2 );
 	}
 

--- a/rkv-site-guide.php
+++ b/rkv-site-guide.php
@@ -7,7 +7,7 @@
  * Description: Adds the site guide to the site.
  * Author: Reaktiv Studios
  * Author URI: https://reaktivstudios.com
- * Version: 2.0.1
+ * Version: 2.0.2
  * License: GPL2+
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  *


### PR DESCRIPTION
This is a temporary change that fixes an issue where editors could not see docs from Notion. We need to work on this so the cap is correctly protected, but move the code over to the source Notion plugin.